### PR TITLE
Improve export arguments

### DIFF
--- a/Epsilon.Cli/Startup.cs
+++ b/Epsilon.Cli/Startup.cs
@@ -63,9 +63,11 @@ public class Startup : IHostedService
         _logger.LogInformation("Targeting Canvas course: {CourseId}, at {Url}", _canvasSettings.CourseId, _canvasSettings.ApiUrl);
         var modules = await _collectionFetcher.GetAll(_canvasSettings.CourseId);
 
-        _logger.LogInformation("Attempting to use following formats: {Formats}", string.Join(", ", _exportOptions.Formats));
-        var exporters = _exporterCollection.DetermineExporters(_exportOptions.Formats).ToArray();
+        var formats = _exportOptions.Formats.Split(",");
+        var exporters = _exporterCollection.DetermineExporters(formats).ToArray();
 
+        _logger.LogInformation("Attempting to use following formats: {Formats}", string.Join(", ", formats));
+        
         foreach (var (format, exporter) in exporters)
         {
             _logger.LogInformation("Exporting to {Format} using {Exporter}...", format, exporter.GetType().Name);

--- a/Epsilon/Export/ExportOptions.cs
+++ b/Epsilon/Export/ExportOptions.cs
@@ -4,7 +4,7 @@ public class ExportOptions
 {
     public string OutputName { get; set; } = "Epsilon-Export-{DateTime}";
 
-    public List<string> Formats { get; } = new();
+    public string Formats { get; set; } = "console";
 
     public string FormattedOutputName => OutputName
         .Replace("{DateTime}", DateTime.Now.ToString("ddMMyyyyHHmmss"));

--- a/Epsilon/Extensions/CoreServiceCollectionExtensions.cs
+++ b/Epsilon/Extensions/CoreServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class CoreServiceCollectionExtensions
     public static IServiceCollection AddCore(this IServiceCollection services, IConfiguration config)
     {
         services.AddCanvas(config.GetSection("Canvas"));
-        services.AddExport(config.GetSection("Export"));
+        services.AddExport(config);
 
         return services;
     }


### PR DESCRIPTION
This pull request closes #22 and replaces the awkward `--export:formats:0 csv --export:formats:1 console` with `--formats csv,console`.

Before merging:

- [ ] Update wiki, how to use