### PR TITLE
Fix light colour scheme in console

### DIFF
--- a/Epsilon.Cli/Epsilon.Cli.csproj
+++ b/Epsilon.Cli/Epsilon.Cli.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Epsilon.Cli/appsettings.example.json
+++ b/Epsilon.Cli/appsettings.example.json
@@ -10,6 +10,7 @@
       {
         "Name": "Console",
         "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Sixteen, Serilog.Sinks.Console",
           "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
         }
       }


### PR DESCRIPTION
Fixes issue #16 

<img width="617" alt="image" src="https://user-images.githubusercontent.com/12190745/198850607-4d4e0263-876a-4faa-bc5e-7f980e5ea1f1.png">
Light example

<img width="595" alt="image" src="https://user-images.githubusercontent.com/12190745/198850629-dab71550-4109-493f-95c8-b814ab1f266a.png">
Dark example
