### PR TITLE
Fix exporters no longer working correctly

### DIFF
--- a/Epsilon.Canvas/Service/OutcomeHttpService.cs
+++ b/Epsilon.Canvas/Service/OutcomeHttpService.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using System.Text;
 using Epsilon.Abstractions.Http;
 using Epsilon.Canvas.Abstractions.Model;
 using Epsilon.Canvas.Abstractions.Service;
@@ -26,10 +25,10 @@ public class OutcomeHttpService : HttpService, IOutcomeHttpService
 
     public async Task<OutcomeResultCollection?> GetResults(int courseId, IEnumerable<string> include)
     {
-        var url = new StringBuilder($"v1/courses/{courseId}/outcome_results");
-        var query = $"?include[]={string.Join("&include[]=", include)}";
+        var url = $"v1/courses/{courseId}/outcome_results?include[]={string.Join("&include[]=", include)}";
+        var requestUri = new Uri(url, UriKind.Relative);
 
-        var responses = await _paginator.GetAllPages<OutcomeResultCollection>(HttpMethod.Get, new Uri(url + query));
+        var responses = await _paginator.GetAllPages<OutcomeResultCollection>(HttpMethod.Get, requestUri);
         var responsesArray = responses.ToArray();
 
         return new OutcomeResultCollection(

--- a/Epsilon.Canvas/Service/PaginatorHttpService.cs
+++ b/Epsilon.Canvas/Service/PaginatorHttpService.cs
@@ -22,10 +22,15 @@ public class PaginatorHttpService : HttpService, IPaginatorHttpService
         var pages = new List<TResult>();
         var page = "1";
 
+        var uriString = uri.OriginalString;
+        uriString += !uriString.Contains('?', StringComparison.InvariantCulture)
+            ? "?"
+            : "&";
+
         do
         {
             var offset = pages.Count * Limit;
-            using var request = new HttpRequestMessage(method, $"{uri}per_page={Limit}&offset={offset}&page={page}");
+            using var request = new HttpRequestMessage(method, $"{uriString}per_page={Limit}&offset={offset}&page={page}");
             var response = await Client.SendAsync(request);
             var value = await response.Content.ReadFromJsonAsync<TResult>();
 

--- a/Epsilon/Export/Exporters/ConsoleModuleExporter.cs
+++ b/Epsilon/Export/Exporters/ConsoleModuleExporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Epsilon.Abstractions.Export;
 using Epsilon.Abstractions.Model;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,7 @@ public class ConsoleModuleExporter : ICanvasModuleExporter
     public async Task<Stream> Export(ExportData data, string format)
     {
         var stream = new MemoryStream();
-        await using var writer = new StreamWriter(stream);
+        await using var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true);
 
         foreach (var module in data.CourseModules)
         {

--- a/Epsilon/Export/Exporters/CsvModuleExporter.cs
+++ b/Epsilon/Export/Exporters/CsvModuleExporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Text;
 using Epsilon.Abstractions.Export;
 using Epsilon.Abstractions.Model;
 
@@ -16,7 +17,7 @@ public class CsvModuleExporter : ICanvasModuleExporter
     public async Task<Stream> Export(ExportData data, string format)
     {
         var stream = new MemoryStream();
-        await using var writer = new StreamWriter(stream);
+        await using var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true);
 
         using var dt = CreateDataTable(data.CourseModules);
         WriteHeader(writer, dt);

--- a/Epsilon/Export/Exporters/WordModuleExporter.cs
+++ b/Epsilon/Export/Exporters/WordModuleExporter.cs
@@ -54,7 +54,7 @@ public class WordModuleExporter : ICanvasModuleExporter
     public async Task<Stream> Export(ExportData data, string format)
     {
         var stream = new MemoryStream();
-        using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
+        var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
 
         document.AddMainDocumentPart();
         document.MainDocumentPart!.Document = new Document(new Body());
@@ -67,25 +67,22 @@ public class WordModuleExporter : ICanvasModuleExporter
 
         var personaHtml = await GetPersonaHtmlDocument(_fileService, data.PersonaHtml);
 
-        using var ms = new MemoryStream(new UTF8Encoding(true).GetPreamble()
-            .Concat(Encoding.UTF8.GetBytes($"<html>{personaHtml.Text}</html>")).ToArray());
+        using var personaHtmlStream = new MemoryStream(Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes($"<html>{personaHtml.Text}</html>")).ToArray());
+        var formatImportPart = document.MainDocumentPart.AddAlternativeFormatImportPart(AlternativeFormatImportPartType.Html, altChunkId);
 
-        var formatImportPart =
-            document.MainDocumentPart.AddAlternativeFormatImportPart(
-                AlternativeFormatImportPartType.Html, altChunkId);
-
-        formatImportPart.FeedData(ms);
+        formatImportPart.FeedData(personaHtmlStream);
         var altChunk = new AltChunk
         {
             Id = altChunkId,
         };
 
         body?.Append(altChunk);
-        await ms.DisposeAsync();
         body?.Append(new Paragraph(new Run(new Break
         {
             Type = BreakValues.Page,
         })));
+
+        await personaHtmlStream.DisposeAsync();
 
         foreach (var module in data.CourseModules)
         {
@@ -146,7 +143,7 @@ public class WordModuleExporter : ICanvasModuleExporter
         htmlDoc.LoadHtml(htmlString);
         if (htmlDoc.DocumentNode.SelectNodes("//img") == null)
         {
-            return null;
+            return htmlDoc;
         }
 
         foreach (var node in htmlDoc.DocumentNode.SelectNodes("//img"))

--- a/Epsilon/Export/Exporters/WordModuleExporter.cs
+++ b/Epsilon/Export/Exporters/WordModuleExporter.cs
@@ -45,8 +45,8 @@ public class WordModuleExporter : ICanvasModuleExporter
 
     public IEnumerable<string> Formats { get; } = new[]
     {
-        "word",
-        "docx",
+        "WORD",
+        "DOCX",
     };
 
     public string FileExtension => "docx";


### PR DESCRIPTION
Some exporters were broken after the coding guidelines addition. These were mainly issues regarding incorrect disposing of stream writers used in the CSV and Console exporters. However, another issue occurred in the Word export regarding the new persona page addition #84 #74, which returned a null homepage when no images were present. This is also fixed in this PR.