### PR TITLE
Add generic Canvas pages

### DIFF
--- a/Epsilon.Abstractions/Component/CompetenceComponentFetcher.cs
+++ b/Epsilon.Abstractions/Component/CompetenceComponentFetcher.cs
@@ -2,7 +2,7 @@ namespace Epsilon.Abstractions.Component;
 
 public abstract class CompetenceComponentFetcher<TComponent> : ICompetenceComponentFetcher<TComponent> where TComponent : ICompetenceComponent
 {
-    public async Task<ICompetenceComponent> FetchUnknown(DateTime startDate, DateTime endDate) => await Fetch(startDate, endDate);
+    public async Task<ICompetenceComponent> FetchUnknown(string componentName, DateTime startDate, DateTime endDate) => await Fetch(componentName,startDate, endDate);
 
-    public abstract Task<TComponent> Fetch(DateTime startDate, DateTime endDate);
+    public abstract Task<TComponent> Fetch(string componentName, DateTime startDate, DateTime endDate);
 }

--- a/Epsilon.Abstractions/Component/CompetenceProfile.cs
+++ b/Epsilon.Abstractions/Component/CompetenceProfile.cs
@@ -1,7 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using Epsilon.Abstractions.Model;
-using Epsilon.Canvas.Abstractions.Model;
 
 namespace Epsilon.Abstractions.Component;
 

--- a/Epsilon.Abstractions/Component/ICompetenceComponentFetcher.cs
+++ b/Epsilon.Abstractions/Component/ICompetenceComponentFetcher.cs
@@ -2,11 +2,11 @@
 
 public interface ICompetenceComponentFetcher
 {
-    public Task<ICompetenceComponent> FetchUnknown(DateTime startDate, DateTime endDate);
+    public Task<ICompetenceComponent> FetchUnknown(string componentName, DateTime startDate, DateTime endDate);
 }
 
 public interface ICompetenceComponentFetcher<TComponent> : ICompetenceComponentFetcher
     where TComponent : ICompetenceComponent
 {
-    public Task<TComponent> Fetch(DateTime startDate, DateTime endDate);
+    public Task<TComponent> Fetch(string componentName, DateTime startDate, DateTime endDate);
 }

--- a/Epsilon.Abstractions/Component/Page.cs
+++ b/Epsilon.Abstractions/Component/Page.cs
@@ -4,15 +4,15 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace Epsilon.Abstractions.Component;
 
-public record PersonaPage(string PersonaHtml) : IWordCompetenceComponent
+public record Page(string Html) : IWordCompetenceComponent
 {
     public void AddToWordDocument(MainDocumentPart mainDocumentPart)
     {
-        var personaHtmlBuffer = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes($"<html>{PersonaHtml}</html>")).ToArray();
-        using var personaHtmlStream = new MemoryStream(personaHtmlBuffer);
+        var htmlBuffer = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes($"<html>{Html}</html>")).ToArray();
+        using var htmlStream = new MemoryStream(htmlBuffer);
 
         var formatImportPart = mainDocumentPart.AddAlternativeFormatImportPart(AlternativeFormatImportPartType.Html);
-        formatImportPart.FeedData(personaHtmlStream);
+        formatImportPart.FeedData(htmlStream);
 
         mainDocumentPart.Document.AppendChild(new Body(
             new AltChunk

--- a/Epsilon.Abstractions/Model/StudentSettings.cs
+++ b/Epsilon.Abstractions/Model/StudentSettings.cs
@@ -1,0 +1,3 @@
+namespace Epsilon.Abstractions.Model;
+
+public record StudentSettings(Dictionary<string, string> PageMapping);

--- a/Epsilon.Abstractions/Service/ICompetenceComponentService.cs
+++ b/Epsilon.Abstractions/Service/ICompetenceComponentService.cs
@@ -4,9 +4,9 @@ namespace Epsilon.Abstractions.Service;
 
 public interface ICompetenceComponentService
 {
-    IAsyncEnumerable<ICompetenceComponent> GetComponents(DateTime startDate, DateTime endDate);
+    IAsyncEnumerable<ICompetenceComponent> GetComponents(string name, DateTime startDate, DateTime endDate);
 
-    IAsyncEnumerable<TComponent> GetComponents<TComponent>(DateTime startDate, DateTime endDate) where TComponent : ICompetenceComponent;
+    IAsyncEnumerable<TComponent> GetComponents<TComponent>(string name, DateTime startDate, DateTime endDate) where TComponent : ICompetenceComponent;
 
     Task<ICompetenceComponent?> GetComponent(string name, DateTime startDate, DateTime endDate);
 

--- a/Epsilon.Abstractions/Service/ICompetenceDocumentService.cs
+++ b/Epsilon.Abstractions/Service/ICompetenceDocumentService.cs
@@ -2,5 +2,5 @@ namespace Epsilon.Abstractions.Service;
 
 public interface ICompetenceDocumentService
 {
-    Task<Stream> WriteDocument(Stream stream, DateTime startDate, DateTime endDate);
+    Task<Stream> WriteDocument(Stream stream, string name, DateTime startDate, DateTime endDate);
 }

--- a/Epsilon.Abstractions/Service/IFilterService.cs
+++ b/Epsilon.Abstractions/Service/IFilterService.cs
@@ -1,4 +1,3 @@
-using Epsilon.Abstractions.Component;
 using Epsilon.Canvas.Abstractions.Model;
 
 namespace Epsilon.Abstractions.Service;

--- a/Epsilon.Host.WebApi/Controllers/DocumentController.cs
+++ b/Epsilon.Host.WebApi/Controllers/DocumentController.cs
@@ -15,10 +15,10 @@ public class DocumentController : Controller
     }
 
     [HttpGet("word")]
-    public async Task<IActionResult> DownloadWordDocument(DateTime startDate, DateTime endDate)
+    public async Task<IActionResult> DownloadWordDocument(string name, DateTime startDate, DateTime endDate)
     {
         var stream = new MemoryStream();
-        await _competenceDocumentService.WriteDocument(stream, startDate, endDate);
+        await _competenceDocumentService.WriteDocument(stream, name, startDate, endDate);
 
         return File(
             stream,

--- a/Epsilon.Host.WebApi/Program.cs
+++ b/Epsilon.Host.WebApi/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddScoped<ICompetenceDocumentService, CompetenceDocumentService
 builder.Services.AddScoped<ICompetenceComponentService, CompetenceComponentService>(static (services) => new CompetenceComponentService(
     new Dictionary<string, ICompetenceComponentFetcher>
     {
-        { "persona_page", services.GetRequiredService<ICompetenceComponentFetcher<Page>>() },
+        { "front_page", services.GetRequiredService<ICompetenceComponentFetcher<Page>>() },
         { "competence_profile", services.GetRequiredService<ICompetenceComponentFetcher<CompetenceProfile>>() },
         { "kpi_matrix", services.GetRequiredService<ICompetenceComponentFetcher<KpiMatrixCollection>>() },
     }

--- a/Epsilon.Host.WebApi/Program.cs
+++ b/Epsilon.Host.WebApi/Program.cs
@@ -30,13 +30,13 @@ builder.Services.AddScoped<ICompetenceDocumentService, CompetenceDocumentService
 builder.Services.AddScoped<ICompetenceComponentService, CompetenceComponentService>(static (services) => new CompetenceComponentService(
     new Dictionary<string, ICompetenceComponentFetcher>
     {
-        { "persona_page", services.GetRequiredService<ICompetenceComponentFetcher<PersonaPage>>() },
+        { "persona_page", services.GetRequiredService<ICompetenceComponentFetcher<Page>>() },
         { "competence_profile", services.GetRequiredService<ICompetenceComponentFetcher<CompetenceProfile>>() },
         { "kpi_matrix", services.GetRequiredService<ICompetenceComponentFetcher<KpiMatrixCollection>>() },
     }
 ));
 
-builder.Services.AddScoped<ICompetenceComponentFetcher<PersonaPage>, PersonaPageComponentFetcher>();
+builder.Services.AddScoped<ICompetenceComponentFetcher<Page>, PageComponentFetcher>();
 builder.Services.AddScoped<ICompetenceComponentFetcher<CompetenceProfile>, CompetenceProfileComponentFetcher>();
 builder.Services.AddScoped<ICompetenceComponentFetcher<KpiMatrixCollection>, KpiMatrixComponentFetcher>();
 

--- a/Epsilon/Component/CompetenceProfileComponentFetcher.cs
+++ b/Epsilon/Component/CompetenceProfileComponentFetcher.cs
@@ -51,7 +51,7 @@ public class CompetenceProfileComponentFetcher : CompetenceComponentFetcher<Comp
         _configuration = configuration;
     }
 
-    public override async Task<CompetenceProfile> Fetch(DateTime startDate, DateTime endDate)
+    public override async Task<CompetenceProfile> Fetch(string componentName, DateTime startDate, DateTime endDate)
     {
         var studentId = _configuration["Canvas:StudentId"];
         var outcomesQuery = GetAllUserCoursesSubmissionOutcomes.Replace("$studentIds", $"{studentId}", StringComparison.InvariantCulture);

--- a/Epsilon/Component/KpiMatrixComponentFetcher.cs
+++ b/Epsilon/Component/KpiMatrixComponentFetcher.cs
@@ -64,7 +64,7 @@ public class KpiMatrixComponentFetcher : CompetenceComponentFetcher<KpiMatrixCol
         _configuration = configuration;
     }
 
-    public override async Task<KpiMatrixCollection> Fetch(DateTime startDate, DateTime endDate)
+    public override async Task<KpiMatrixCollection> Fetch(string componentName, DateTime startDate, DateTime endDate)
     {
         var studentId = _configuration["Canvas:StudentId"];
         var outcomesQuery = GetUserKpiMatrixOutcomes.Replace("$studentIds", $"{studentId}", StringComparison.InvariantCultureIgnoreCase);

--- a/Epsilon/Component/PageComponentFetcher.cs
+++ b/Epsilon/Component/PageComponentFetcher.cs
@@ -1,4 +1,5 @@
 ﻿using Epsilon.Abstractions.Component;
+using Epsilon.Abstractions.Model;
 using Epsilon.Canvas;
 using Epsilon.Canvas.Abstractions.Service;
 using HtmlAgilityPack;
@@ -6,36 +7,40 @@ using Microsoft.Extensions.Options;
 
 namespace Epsilon.Component;
 
-public class PersonaPageComponentFetcher : CompetenceComponentFetcher<PersonaPage>
+public class PageComponentFetcher : CompetenceComponentFetcher<Page>
 {
     private readonly IPageHttpService _pageHttpService;
     private readonly IFileHttpService _fileHttpService;
     private readonly CanvasSettings _canvasSettings;
+    private readonly StudentSettings _studentSettings;
 
-    public PersonaPageComponentFetcher(
+    public PageComponentFetcher(
         IPageHttpService pageHttpService,
         IFileHttpService fileHttpService,
-        IOptions<CanvasSettings> canvasSettings
+        IOptions<CanvasSettings> canvasSettings,
+        StudentSettings studentSettings
     )
     {
         _pageHttpService = pageHttpService;
         _fileHttpService = fileHttpService;
         _canvasSettings = canvasSettings.Value;
+        _studentSettings = studentSettings;
     }
 
-    public override async Task<PersonaPage> Fetch(DateTime startDate, DateTime endDate)
+    public override async Task<Page> Fetch(DateTime startDate, DateTime endDate)
     {
         var courseId = _canvasSettings.CourseId;
-        var personaHtml = await _pageHttpService.GetPageByName(courseId, "front_page");
+        var htmlString = await _pageHttpService.GetPageByName(courseId, _studentSettings.PageMapping[""]);
 
-        var updatedPersonaHtml = await GetPersonaHtmlDocument(personaHtml);
+        var updatedPersonaHtml = await GetHtmlDocument(htmlString);
 
-        var personaPage = new PersonaPage(updatedPersonaHtml.Text);
+        var page = new Page(updatedPersonaHtml.Text);
 
-        return personaPage;
+        return page;
     }
 
-    private async Task<HtmlDocument> GetPersonaHtmlDocument(string htmlString)
+
+    private async Task<HtmlDocument> GetHtmlDocument(string htmlString)
     {
         var htmlDoc = new HtmlDocument();
         htmlDoc.LoadHtml(htmlString);
@@ -62,5 +67,4 @@ public class PersonaPageComponentFetcher : CompetenceComponentFetcher<PersonaPag
 
         return htmlDoc;
     }
-
 }

--- a/Epsilon/Component/PageComponentFetcher.cs
+++ b/Epsilon/Component/PageComponentFetcher.cs
@@ -1,5 +1,4 @@
 ﻿using Epsilon.Abstractions.Component;
-using Epsilon.Abstractions.Model;
 using Epsilon.Canvas;
 using Epsilon.Canvas.Abstractions.Service;
 using HtmlAgilityPack;
@@ -12,25 +11,25 @@ public class PageComponentFetcher : CompetenceComponentFetcher<Page>
     private readonly IPageHttpService _pageHttpService;
     private readonly IFileHttpService _fileHttpService;
     private readonly CanvasSettings _canvasSettings;
-    private readonly StudentSettings _studentSettings;
+    // private readonly StudentSettings _studentSettings;
 
     public PageComponentFetcher(
         IPageHttpService pageHttpService,
         IFileHttpService fileHttpService,
-        IOptions<CanvasSettings> canvasSettings,
-        StudentSettings studentSettings
-    )
+        IOptions<CanvasSettings> canvasSettings
+        // IOptions<StudentSettings> studentSettings
+        )
     {
         _pageHttpService = pageHttpService;
         _fileHttpService = fileHttpService;
         _canvasSettings = canvasSettings.Value;
-        _studentSettings = studentSettings;
+        // _studentSettings = studentSettings.Value;
     }
 
-    public override async Task<Page> Fetch(DateTime startDate, DateTime endDate)
+    public override async Task<Page> Fetch(string componentName, DateTime startDate, DateTime endDate)
     {
         var courseId = _canvasSettings.CourseId;
-        var htmlString = await _pageHttpService.GetPageByName(courseId, _studentSettings.PageMapping[""]);
+        var htmlString = await _pageHttpService.GetPageByName(courseId, componentName);
 
         var updatedPersonaHtml = await GetHtmlDocument(htmlString);
 

--- a/Epsilon/Service/CompetenceComponentService.cs
+++ b/Epsilon/Service/CompetenceComponentService.cs
@@ -12,17 +12,17 @@ public class CompetenceComponentService : ICompetenceComponentService
         _componentFetchers = componentFetchers;
     }
 
-    public async IAsyncEnumerable<ICompetenceComponent> GetComponents(DateTime startDate, DateTime endDate)
+    public async IAsyncEnumerable<ICompetenceComponent> GetComponents(string name, DateTime startDate, DateTime endDate)
     {
         foreach (var componentFetcher in _componentFetchers.Values)
         {
-            yield return await componentFetcher.FetchUnknown(startDate, endDate);
+            yield return await componentFetcher.FetchUnknown(name, startDate, endDate);
         }
     }
 
-    public async IAsyncEnumerable<TComponent> GetComponents<TComponent>(DateTime startDate, DateTime endDate) where TComponent : ICompetenceComponent
+    public async IAsyncEnumerable<TComponent> GetComponents<TComponent>(string name, DateTime startDate, DateTime endDate) where TComponent : ICompetenceComponent
     {
-        await foreach (var component in GetComponents(startDate, endDate))
+        await foreach (var component in GetComponents(name,startDate, endDate))
         {
             if (component is TComponent componentOfT)
             {
@@ -35,7 +35,7 @@ public class CompetenceComponentService : ICompetenceComponentService
     {
         if (_componentFetchers.TryGetValue(name, out var fetcher))
         {
-            return await fetcher.FetchUnknown(startDate, endDate);
+            return await fetcher.FetchUnknown(name, startDate, endDate);
         }
 
         return null;

--- a/Epsilon/Service/CompetenceDocumentService.cs
+++ b/Epsilon/Service/CompetenceDocumentService.cs
@@ -15,11 +15,11 @@ public class CompetenceDocumentService : ICompetenceDocumentService
         _competenceComponentService = competenceComponentService;
     }
 
-    public async Task<Stream> WriteDocument(Stream stream, DateTime startDate, DateTime endDate)
+    public async Task<Stream> WriteDocument(Stream stream, string name, DateTime startDate, DateTime endDate)
     {
         var startPosition = stream.Position;
 
-        var components = await _competenceComponentService.GetComponents<IWordCompetenceComponent>(startDate, endDate).ToListAsync();
+        var components = await _competenceComponentService.GetComponents<IWordCompetenceComponent>(name, startDate, endDate).ToListAsync();
         using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
 
         document.AddMainDocumentPart();

--- a/Epsilon/Service/FilterService.cs
+++ b/Epsilon/Service/FilterService.cs
@@ -1,4 +1,3 @@
-using DocumentFormat.OpenXml;
 using Epsilon.Abstractions.Service;
 using Epsilon.Canvas.Abstractions.Model;
 using Epsilon.Canvas.Abstractions.Model.GraphQl;


### PR DESCRIPTION
**Motivation**
This merge request aims to enhance the student's competence document by allowing them to display various canvas pages, such as a page dedicated to their personal reflection. 

**Description**
The core modification in this merge request involves transforming the implementation of the persona page into a more flexible, generic canvas page implementation. This enables the student to create and display different types of canvas pages within their competence document.