### PR TITLE
Add missing component fetcher services to service collection

### DIFF
--- a/Epsilon.Host.WebApi/Program.cs
+++ b/Epsilon.Host.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Epsilon.Abstractions.Component;
 using Epsilon.Abstractions.Service;
 using Epsilon.Canvas;
+using Epsilon.Component;
 using Epsilon.Service;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,6 +35,11 @@ builder.Services.AddScoped<ICompetenceComponentService, CompetenceComponentServi
         { "kpi_matrix", services.GetRequiredService<ICompetenceComponentFetcher<KpiMatrixCollection>>() },
     }
 ));
+
+builder.Services.AddScoped<ICompetenceComponentFetcher<PersonaPage>, PersonaPageComponentFetcher>();
+builder.Services.AddScoped<ICompetenceComponentFetcher<CompetenceProfile>, CompetenceProfileComponentFetcher>();
+builder.Services.AddScoped<ICompetenceComponentFetcher<KpiMatrixCollection>, KpiMatrixComponentFetcher>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
For some reason the component fetcher services got removed in PR #96, this reconfigures them for the service collection.