### PR TITLE
Trigger code analyis on PR and parallelize deployment pipeline

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,9 +1,16 @@
 name: "Code analysis"
 
 on:
-  workflow_run:
-    workflows: [ "Continuous integration" ]
-    types: [ completed ]
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.yml'
+      - '**.cs'
+      - '**.json'
+      - '**.csproj'
+      - '**.ts'
+      - '**.vue'
+      - '**.css'
   schedule:
     - cron: '22 18 * * 5'
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -26,7 +26,7 @@ jobs:
           file: ./Epsilon.Host.WebApi/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}-api
-          labels: ${{ steps.meta.outputs.labels }}-API
+          labels: ${{ steps.meta.outputs.labels }}-api
   
   frontend:
     name: Build frontend Docker image and publish
@@ -49,4 +49,4 @@ jobs:
           context: ./Epsilon.Host.Frontend
           push: true
           tags: ${{ steps.meta.outputs.tags }}-frontend
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta.outputs.labels }}-frontend

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -20,13 +20,6 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: typiqally/epsilon
-      - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: typiqally/epsilon
       - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
@@ -46,13 +39,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: typiqally/epsilon
-      - name: Check out the repo
-        uses: actions/checkout@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -2,10 +2,10 @@ name: Continuous deployment
 on:
   workflow_dispatch:
   push:
-    branches: [ master,develop ]
+    branches: [ master, develop ]
 jobs:
   api:
-    name: Api building and publishing
+    name: Build API Docker image and publish
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -29,7 +29,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}-API
   
   frontend:
-    name: frontend building and publishing
+    name: Build frontend Docker image and publish
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [login]
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -45,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [login]
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches: [ master,develop ]
 jobs:
-  login:
-    name: Login and define docker image
+  api:
+    name: Api building and publishing
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -21,12 +20,6 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: typiqally/epsilon
-  
-  build-api:
-    name: Build and push Docker image API
-    runs-on: ubuntu-latest
-    needs: [login]
-    steps:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Extract metadata (tags, labels) for Docker
@@ -42,11 +35,22 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}-api
           labels: ${{ steps.meta.outputs.labels }}-API
   
-  build-frontend:
-    name: Build and push Docker image API
+  frontend:
+    name: Api building and publishing
     runs-on: ubuntu-latest
-    needs: [login]
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: typiqally/epsilon
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Extract metadata (tags, labels) for Docker
@@ -57,7 +61,6 @@ jobs:
       - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./Epsilon.Host.Frontend
-          secrets: VITE_EPSILON_API_ENDPOINT=https://staging-epsilon.tpcly.com/api
           push: true
           tags: ${{ steps.meta.outputs.tags }}-frontend
-          labels: ${{ steps.meta.outputs.labels }}    
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -27,6 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [login]
     steps:
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: typiqally/epsilon
       - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
@@ -40,6 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [login]
     steps:
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: typiqally/epsilon
       - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./Epsilon.Host.Frontend

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -2,10 +2,10 @@ name: Continuous deployment
 on:
   workflow_dispatch:
   push:
-    branches: [master,develop]
+    branches: [ master,develop ]
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  login:
+    name: Login and define docker image
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -16,29 +16,34 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: typiqally/epsilon
-
-      - name: Build and push Docker image API
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+  
+  build-api:
+    name: Build and push Docker image API
+    runs-on: ubuntu-latest
+    needs: [login]
+    steps:
+      - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
           file: ./Epsilon.Host.WebApi/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}-api
           labels: ${{ steps.meta.outputs.labels }}-API
-
-
-      - name: Build and push Docker image Frontend
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+  
+  build-frontend:
+    name: Build and push Docker image API
+    runs-on: ubuntu-latest
+    needs: [login]
+    steps:
+      - uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./Epsilon.Host.Frontend
           secrets: VITE_EPSILON_API_ENDPOINT=https://staging-epsilon.tpcly.com/api
           push: true
           tags: ${{ steps.meta.outputs.tags }}-frontend
-          labels: ${{ steps.meta.outputs.labels }}
-    
+          labels: ${{ steps.meta.outputs.labels }}    

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -29,7 +29,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}-API
   
   frontend:
-    name: Api building and publishing
+    name: frontend building and publishing
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,10 +1,8 @@
 name: Continuous deployment
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [ "Continuous integration" ]
-    branches: [ main, develop ]
-    types: [ completed ]
+  push:
+    branches: [master,develop]
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
On every push to master and develop docker, images will be created. 

code analysis has been returned to trigger on pull_request
Now it is also used to validate the code base and allow or dismiss the pull request. 
